### PR TITLE
Fix a fgetline() crash when reading EOF.

### DIFF
--- a/model.c
+++ b/model.c
@@ -534,7 +534,8 @@ ptrdiff_t fgetline(char **line, size_t *size, FILE *in) {
         if (ch == '\n')
             break;
     }
-    (*line)[len] = 0;
+    if (*line != NULL)
+        (*line)[len] = 0;
     ptrdiff_t ret = len;
     return ret < 1 ? -1 : ret;
 }


### PR DESCRIPTION
Issue can be reproduced with:

    ./crctest < /dev/null

The crash happen here, due a null pointer dereference:
https://github.com/madler/crcany/blob/v2.1/model.c#L537

This commit fixes this crash.

Signed-off-by: Julien Olivain <ju.o@free.fr>